### PR TITLE
Relative imports

### DIFF
--- a/scripts/sift
+++ b/scripts/sift
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 set -e
 

--- a/scripts/sift
+++ b/scripts/sift
@@ -1,3 +1,4 @@
+
 #!/bin/bash
 set -e
 
@@ -37,5 +38,5 @@ $SPARK_HOME/bin/spark-submit \
     $SPARK_MASTER_SW \
     --driver-memory 8g \
     --executor-memory 8g \
-    sift/__main__.py \
+    $(dirname $0)/sift-worker.py \
     "$@"

--- a/scripts/sift-worker.py
+++ b/scripts/sift-worker.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python
+import os
+import sys
+sys.path.append(os.path.dirname(os.path.abspath(os.path.join(__file__, '..'))))
+
+from sift import main
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     license = 'MIT',
     url = 'https://github.com/wikilinks/sift',
     scripts = {
-        'scripts/sift'
+        'scripts/sift',
+        'scripts/sift-worker.py'
     },
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/sift/__init__.py
+++ b/sift/__init__.py
@@ -1,0 +1,38 @@
+import argparse
+import re
+import sys
+import textwrap
+
+from . import build
+
+import logging
+log = logging.getLogger()
+
+logFormat = '%(asctime)s|%(levelname)s|%(module)s|%(message)s'
+logging.basicConfig(format=logFormat)
+log = logging.getLogger()
+log.setLevel(logging.INFO)
+
+APPS = [
+    build.BuildModel
+]
+
+def main(args=sys.argv[1:]):
+    p = argparse.ArgumentParser(description='Extract text models from corpus of documents.')
+    sp = p.add_subparsers()
+    for cls in APPS:
+        name = re.sub('([A-Z])', r'-\1', cls.__name__).lstrip('-').lower()
+        help = cls.__doc__.split('\n')[0]
+        desc = textwrap.dedent(cls.__doc__.rstrip())
+        csp = sp.add_parser(name,
+                            help=help,
+                            description=desc,
+                            formatter_class=argparse.RawDescriptionHelpFormatter)
+        cls.add_arguments(csp)
+    namespace = vars(p.parse_args(args))
+    cls = namespace.pop('cls')
+    try:
+        obj = cls(**namespace)
+    except ValueError as e:
+        p.error(str(e))
+    obj()

--- a/sift/__main__.py
+++ b/sift/__main__.py
@@ -1,42 +1,4 @@
-#!/usr/bin/env python
-import argparse
-import re
-import sys
-import textwrap
-
-import build
-
-import logging
-log = logging.getLogger()
-
-logFormat = '%(asctime)s|%(levelname)s|%(module)s|%(message)s'
-logging.basicConfig(format=logFormat)
-log = logging.getLogger()
-log.setLevel(logging.INFO)
-
-APPS = [
-    build.BuildModel
-]
-
-def main(args=sys.argv[1:]):
-    p = argparse.ArgumentParser(description='Extract text models from corpus of documents.')
-    sp = p.add_subparsers()
-    for cls in APPS:
-        name = re.sub('([A-Z])', r'-\1', cls.__name__).lstrip('-').lower()
-        help = cls.__doc__.split('\n')[0]
-        desc = textwrap.dedent(cls.__doc__.rstrip())
-        csp = sp.add_parser(name,
-                            help=help,
-                            description=desc,
-                            formatter_class=argparse.RawDescriptionHelpFormatter)
-        cls.add_arguments(csp)
-    namespace = vars(p.parse_args(args))
-    cls = namespace.pop('cls')
-    try:
-        obj = cls(**namespace)
-    except ValueError as e:
-        p.error(str(e))
-    obj()
+from . import main
 
 if __name__ == '__main__':
     main()

--- a/sift/build.py
+++ b/sift/build.py
@@ -7,7 +7,7 @@ import ujson as json
 
 from pyspark import SparkContext, SparkConf
 
-from models import links, text
+from .models import links, text
 
 import logging
 log = logging.getLogger() 

--- a/sift/models/__init__.py
+++ b/sift/models/__init__.py
@@ -1,6 +1,6 @@
 import textwrap
 import argparse
-from sift.format import ModelFormat, JsonFormat
+from ..format import ModelFormat, JsonFormat
 
 class Model(object):
     def __init__(self, **kwargs):

--- a/sift/models/links.py
+++ b/sift/models/links.py
@@ -3,8 +3,8 @@ import ujson as json
 from operator import add
 from collections import Counter
 
-from sift.models import Model
-from sift.util import trim_link_subsection, trim_link_protocol
+from ..models import Model
+from ..util import trim_link_subsection, trim_link_protocol
 
 import logging
 log = logging.getLogger()

--- a/sift/models/text.py
+++ b/sift/models/text.py
@@ -5,8 +5,8 @@ from bisect import bisect_left, bisect_right
 from operator import add
 from collections import Counter
 
-from sift.models import Model
-from sift.util import ngrams, iter_sent_spans, trim_link_subsection, trim_link_protocol
+from ..models import Model
+from ..util import ngrams, iter_sent_spans, trim_link_subsection, trim_link_protocol
 
 import logging
 log = logging.getLogger()


### PR DESCRIPTION
I think this structure is better than the one you used previously. First, doing relative imports make clear that they should be satisfied within the package (in my environment the code didn't work from the checked-out repository without setting PYTHONPATH). Second, if you execute `__main__.py` directly from `spark-submit` python doesn't know the full package name, hence I added two entry points (sift-worker.py and **main**.py). I hope this also works for you.
