### PR TITLE
add cli option for toggling lowercase

### DIFF
--- a/sift/build.py
+++ b/sift/build.py
@@ -67,6 +67,7 @@ class BuildModel(object):
         p.add_argument('corpus_path', metavar='CORPUS_PATH')
         p.add_argument('--save', dest='output_path', required=False, default=None, metavar='OUTPUT_PATH')
         p.add_argument('--sample', dest='sample', required=False, default=0, type=int, metavar='N')
+        p.add_argument('--lowercase', dest='lowercase', required=False, default=False, action='store_true')
         p.set_defaults(cls=cls)
 
         sp = p.add_subparsers()

--- a/sift/build.py
+++ b/sift/build.py
@@ -67,7 +67,6 @@ class BuildModel(object):
         p.add_argument('corpus_path', metavar='CORPUS_PATH')
         p.add_argument('--save', dest='output_path', required=False, default=None, metavar='OUTPUT_PATH')
         p.add_argument('--sample', dest='sample', required=False, default=0, type=int, metavar='N')
-        p.add_argument('--lowercase', dest='lowercase', required=False, default=False, action='store_true')
         p.set_defaults(cls=cls)
 
         sp = p.add_subparsers()

--- a/sift/models/links.py
+++ b/sift/models/links.py
@@ -30,11 +30,15 @@ class EntityCounts(Model):
 
 class EntityNameCounts(Model):
     """ Entity counts by name """
-    @staticmethod
-    def iter_link_anchor_target_pairs(doc):
+    def __init__(self, **kwargs):
+        self.lowercase = kwargs.pop('lowercase')
+        super(EntityNameCounts, self).__init__(**kwargs)
+
+    def iter_link_anchor_target_pairs(self, doc):
         for link in doc['links']:
             anchor = doc['text'][link['start']:link['stop']]
-            anchor = anchor.strip().lower()
+            if self.lowercase:
+                anchor = anchor.strip().lower()
             yield anchor, link['target']
 
     def build(self, corpus):

--- a/sift/models/links.py
+++ b/sift/models/links.py
@@ -58,6 +58,15 @@ class EntityNameCounts(Model):
                 'total': sum(counts.itervalues())
             })
 
+    @classmethod
+    def add_model_arguments(cls, p):
+        p.add_argument('--lowercase', dest='lowercase', required=False, default=False, action='store_true')
+
+    @classmethod
+    def add_arguments(cls, p):
+        cls.add_model_arguments(p)
+        return super(EntityNameCounts, cls).add_arguments(p)
+
 class EntityInlinks(Model):
     """ Comention counts """
     def build(self, corpus):


### PR DESCRIPTION
This patch allows to keep the original anchor names. In our use-case we want to work with the original strings instead of lowercased versions. The toggle switch is not ideal at that location, but didn't find a more suitable place without adding more code.
